### PR TITLE
Conditionally compile X11 code

### DIFF
--- a/include/External/x11.h
+++ b/include/External/x11.h
@@ -1,9 +1,6 @@
+#pragma once
+
 #ifdef HAVE_X11
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
-#else
-typedef struct {
-} xcb_connection_t;
-typedef struct {
-} xcb_window_t;
 #endif

--- a/include/Windowing/RawHandle.h
+++ b/include/Windowing/RawHandle.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef HAVE_X11
 #include "External/x11.h"
+#endif
 #include <functional>
 #include <optional>
 
@@ -9,14 +11,21 @@ struct RawWindowHandle {
 public:
   enum class Type {
     None,
+#ifdef HAVE_X11
     X11,
+#endif
   };
 
   union Handle {
+#ifdef HAVE_X11
     struct {
       xcb_connection_t *connection;
       xcb_window_t window;
     } x11;
+#else
+    struct {
+    } none;
+#endif
   };
 
 private:
@@ -26,7 +35,9 @@ private:
 public:
   RawWindowHandle();
   RawWindowHandle(Type type, Handle handle);
+#ifdef HAVE_X11
   RawWindowHandle(xcb_connection_t *connection, xcb_window_t window);
+#endif
 
   Type getType() const { return type; }
   std::optional<std::reference_wrapper<const Handle>> getHandle() const {

--- a/include/Windowing/XWindow.h
+++ b/include/Windowing/XWindow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef HAVE_X11
+
 #include "Windowing/Descriptor.h"
 #include "Windowing/RawHandle.h"
 #include "Utility/Result.h"
@@ -64,3 +66,5 @@ public:
   static Result<XWindow, Error> create(const Descriptor &desc);
 };
 } // namespace yawl
+
+#endif // HAVE_X11

--- a/include/Yawl.h
+++ b/include/Yawl.h
@@ -7,4 +7,6 @@
 
 #include "Windowing/Descriptor.h"
 #include "Windowing/RawHandle.h"
+#ifdef HAVE_X11
 #include "Windowing/XWindow.h"
+#endif

--- a/src/RawHandle.cc
+++ b/src/RawHandle.cc
@@ -4,6 +4,7 @@ namespace yawl {
 RawWindowHandle::RawWindowHandle() : type(Type::None), handle(std::nullopt) {}
 RawWindowHandle::RawWindowHandle(Type type, Handle handle)
     : type(type), handle(handle) {}
+#ifdef HAVE_X11
 RawWindowHandle::RawWindowHandle(xcb_connection_t *connection,
                                  xcb_window_t window)
     : type(RawWindowHandle::Type::X11) {
@@ -12,4 +13,5 @@ RawWindowHandle::RawWindowHandle(xcb_connection_t *connection,
   h.x11.window = window;
   handle = h;
 }
+#endif
 } // namespace yawl

--- a/src/XWindow.cc
+++ b/src/XWindow.cc
@@ -1,3 +1,5 @@
+#ifdef HAVE_X11
+
 #include "Utility/Result.h"
 #include "Utility/Value.h"
 #include <Windowing/XWindow.h>
@@ -162,3 +164,5 @@ Result<XWindow, XWindow::Error> XWindow::create(const Descriptor &desc) {
 }
 
 } // namespace yawl
+
+#endif // HAVE_X11


### PR DESCRIPTION
## Summary
- compile X11 headers only when `HAVE_X11` is defined
- wrap `XWindow` headers/sources in `HAVE_X11`
- guard raw X11 handle code in `RawHandle` behind `HAVE_X11`
- include XWindow only when available

## Testing
- `cmake ..`
- `make`
- `./yawl_example` (fails to create window due to environment)

------
https://chatgpt.com/codex/tasks/task_e_686265192b7c8333880a7d1d93c1ef62