### PR TITLE
Refactor XPoller with conditional handlers

### DIFF
--- a/example.cc
+++ b/example.cc
@@ -5,9 +5,11 @@
 struct Handler : public yawl::Handler {
   void onEvent(yawl::EventLoop &loop, yawl::WindowId id,
                yawl::Event &event) override {
-    if (event.type == yawl::Event::Type::CloseRequest) {
-      std::cout << "Received close request for window ID: " << id << std::endl;
+    switch (event.type) {
+    case yawl::Event::Type::CloseRequest:
+      std::cout << "Close request received for window ID: " << id << std::endl;
       loop.unmount(id);
+      break;
     }
   }
 };

--- a/include/Event/Loop.h
+++ b/include/Event/Loop.h
@@ -8,12 +8,26 @@
 #include <vector>
 
 namespace yawl {
+#ifdef HAVE_X11
+struct XPoller;
+#endif
 struct EventLoop {
+#ifdef HAVE_X11
+  friend struct XPoller;
+#endif
 private:
-  RingBuffer<Event, 12> eventQueue;
+  struct QueuedEvent {
+    WindowId id;
+    Event event;
+  };
+
+  RingBuffer<QueuedEvent, 12> eventQueue;
   std::vector<std::unique_ptr<Window>> windows;
   bool running;
   Handler &handler;
+
+  void dispatchQueuedEvents();
+  void queueEvent(WindowId id, const Event &event);
 
 public:
   EventLoop(Handler &h);

--- a/include/Event/XPoller.h
+++ b/include/Event/XPoller.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef HAVE_X11
+#include "Event/Handler.h"
+#include "Windowing/Window.h"
+#include <External/x11.h>
+
+namespace yawl {
+struct EventLoop;
+
+struct XPoller {
+  void poll(EventLoop &loop, WindowId id, Window &window);
+
+private:
+  void handleEvent(EventLoop &loop, WindowId id, xcb_generic_event_t *ev);
+  void handleClientMessage(EventLoop &loop, WindowId id,
+                           xcb_client_message_event_t *ev);
+  void handleDestroyNotify(EventLoop &loop, WindowId id,
+                           xcb_destroy_notify_event_t *ev);
+};
+} // namespace yawl
+#endif // HAVE_X11

--- a/src/Event/Loop.cc
+++ b/src/Event/Loop.cc
@@ -1,7 +1,14 @@
 #include "Event/Loop.h"
+#ifdef HAVE_X11
+#include "Event/XPoller.h"
+#endif
 
 namespace yawl {
-EventLoop::EventLoop(Handler &h) : handler(h), running(true) {}
+EventLoop::EventLoop(Handler &h) : running(true), handler(h) {}
+
+void EventLoop::queueEvent(WindowId id, const Event &event) {
+  eventQueue.push({id, event});
+}
 
 WindowId EventLoop::mount(std::unique_ptr<Window> window) {
   windows.push_back(std::move(window));
@@ -15,8 +22,27 @@ void EventLoop::unmount(WindowId id) {
   }
 }
 
+
+void EventLoop::dispatchQueuedEvents() {
+  while (!eventQueue.isEmpty()) {
+    auto res = eventQueue.pop();
+    if (res.is_ok()) {
+      auto qe = std::move(res.value());
+      handler.onEvent(*this, qe.id, qe.event);
+    }
+  }
+}
+
 void EventLoop::run() {
   while (!windows.empty() && running) {
+    for (WindowId i = 0; i < windows.size(); ++i) {
+#ifdef HAVE_X11
+      XPoller poller;
+      poller.poll(*this, i, *windows[i]);
+#endif
+    }
+
+    dispatchQueuedEvents();
   }
 }
 } // namespace yawl

--- a/src/Event/XPoller.cc
+++ b/src/Event/XPoller.cc
@@ -1,0 +1,58 @@
+#include "Event/XPoller.h"
+
+#ifdef HAVE_X11
+#include "Event/Loop.h"
+#include <External/x11.h>
+#include <cstdlib>
+
+namespace yawl {
+
+void XPoller::poll(EventLoop &loop, WindowId id, Window &window) {
+  RawWindowHandle handle = window.getWindowHandle();
+  if (handle.getType() != RawWindowHandle::Type::X11)
+    return;
+
+  auto optHandle = handle.getHandle();
+  if (!optHandle)
+    return;
+
+  const auto &h = optHandle->get();
+  xcb_generic_event_t *ev = nullptr;
+  while ((ev = xcb_poll_for_event(h.x11.connection)) != nullptr) {
+    handleEvent(loop, id, ev);
+    std::free(ev);
+  }
+}
+
+void XPoller::handleEvent(EventLoop &loop, WindowId id, xcb_generic_event_t *ev) {
+  uint8_t type = ev->response_type & ~0x80;
+  switch (type) {
+  case XCB_CLIENT_MESSAGE:
+    handleClientMessage(loop, id,
+                        reinterpret_cast<xcb_client_message_event_t *>(ev));
+    break;
+  case XCB_DESTROY_NOTIFY:
+    handleDestroyNotify(loop, id,
+                        reinterpret_cast<xcb_destroy_notify_event_t *>(ev));
+    break;
+  default:
+    break;
+  }
+}
+
+void XPoller::handleClientMessage(EventLoop &loop, WindowId id,
+                                  xcb_client_message_event_t *ev) {
+  (void)ev;
+  Event e{Event::Type::CloseRequest, {}};
+  loop.queueEvent(id, e);
+}
+
+void XPoller::handleDestroyNotify(EventLoop &loop, WindowId id,
+                                  xcb_destroy_notify_event_t *ev) {
+  (void)ev;
+  Event e{Event::Type::CloseRequest, {}};
+  loop.queueEvent(id, e);
+}
+
+} // namespace yawl
+#endif // HAVE_X11


### PR DESCRIPTION
## Summary
- guard XPoller with `HAVE_X11`
- split X11 polling into smaller handler methods
- call XPoller only when X11 support is available

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/yawl_example` *(fails: Failed to create window: 0)*


------
https://chatgpt.com/codex/tasks/task_e_68626eecbe348333902ed3bf9deb7d45