### PR TITLE
Introduce shared X11 client

### DIFF
--- a/example.cc
+++ b/example.cc
@@ -1,10 +1,8 @@
-
 #include <Yawl.h>
 #include <iostream>
 
 struct Handler : public yawl::Handler {
-  void onEvent(yawl::EventLoop &loop, yawl::WindowId id,
-               yawl::Event &event) override {
+  void onEvent(yawl::EventLoop &loop, yawl::WindowId id, yawl::Event &event) override {
     switch (event.type) {
     case yawl::Event::Type::CloseRequest:
       std::cout << "Close request received for window ID: " << id << std::endl;
@@ -16,16 +14,21 @@ struct Handler : public yawl::Handler {
 
 int main() {
   Handler handler;
-  yawl::EventLoop eventLoop(handler);
-
 #ifdef HAVE_X11
+  auto clientRes = yawl::XClient::connect();
+  if (clientRes.is_err()) {
+    std::cerr << "Failed to connect to X server" << std::endl;
+    return 1;
+  }
+  yawl::XClient client = std::move(clientRes.value());
+  yawl::EventLoop eventLoop(handler, client.getPoller());
+
   yawl::Descriptor desc;
   desc.setDimensions(yawl::Size<size_t>::create(800, 600).value())
       .setName("Yawl Example Window");
-  auto result = yawl::XWindow::create(desc);
+  auto result = yawl::XWindow::create(client, desc);
   if (result.is_err()) {
-    std::cerr << "Failed to create window: " << static_cast<int>(result.error())
-              << std::endl;
+    std::cerr << "Failed to create window: " << static_cast<int>(result.error()) << std::endl;
     return 1;
   }
 
@@ -34,8 +37,8 @@ int main() {
 
   eventLoop.mount(std::make_unique<yawl::XWindow>(std::move(window)));
 #else
-  std::cerr << "X11 support is not enabled. Please compile with X11 support."
-            << std::endl;
+  yawl::EventLoop eventLoop(handler);
+  std::cerr << "X11 support is not enabled. Please compile with X11 support." << std::endl;
   return 1;
 #endif
 

--- a/include/Event/Loop.h
+++ b/include/Event/Loop.h
@@ -2,19 +2,19 @@
 
 #include "Event/Event.h"
 #include "Event/Handler.h"
+#include "Event/Poller.h"
 #include "Utility/Ring.h"
 #include "Windowing/Window.h"
 #include <memory>
 #include <vector>
+#ifdef HAVE_X11
+#include <unordered_map>
+#include <optional>
+#include <External/x11.h>
+#endif
 
 namespace yawl {
-#ifdef HAVE_X11
-struct XPoller;
-#endif
 struct EventLoop {
-#ifdef HAVE_X11
-  friend struct XPoller;
-#endif
 private:
   struct QueuedEvent {
     WindowId id;
@@ -23,17 +23,26 @@ private:
 
   RingBuffer<QueuedEvent, 12> eventQueue;
   std::vector<std::unique_ptr<Window>> windows;
+#ifdef HAVE_X11
+  std::unordered_map<xcb_window_t, WindowId> x11WindowMap;
+#endif
   bool running;
   Handler &handler;
+  Poller *poller;
 
   void dispatchQueuedEvents();
-  void queueEvent(WindowId id, const Event &event);
 
 public:
-  EventLoop(Handler &h);
+  EventLoop(Handler &h, Poller *poller = nullptr);
+
+#ifdef HAVE_X11
+  std::optional<WindowId> getWindowId(xcb_window_t win) const;
+#endif
 
   WindowId mount(std::unique_ptr<Window> window);
   void unmount(WindowId id);
+
+  void queueEvent(WindowId id, const Event &event);
 
   void run();
 

--- a/include/Event/Loop.h
+++ b/include/Event/Loop.h
@@ -7,11 +7,7 @@
 #include "Windowing/Window.h"
 #include <memory>
 #include <vector>
-#ifdef HAVE_X11
-#include <unordered_map>
-#include <optional>
-#include <External/x11.h>
-#endif
+
 
 namespace yawl {
 struct EventLoop {
@@ -23,9 +19,6 @@ private:
 
   RingBuffer<QueuedEvent, 12> eventQueue;
   std::vector<std::unique_ptr<Window>> windows;
-#ifdef HAVE_X11
-  std::unordered_map<xcb_window_t, WindowId> x11WindowMap;
-#endif
   bool running;
   Handler &handler;
   Poller *poller;
@@ -35,9 +28,6 @@ private:
 public:
   EventLoop(Handler &h, Poller *poller = nullptr);
 
-#ifdef HAVE_X11
-  std::optional<WindowId> getWindowId(xcb_window_t win) const;
-#endif
 
   WindowId mount(std::unique_ptr<Window> window);
   void unmount(WindowId id);

--- a/include/Event/Poller.h
+++ b/include/Event/Poller.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace yawl {
+struct EventLoop;
+
+struct Poller {
+  virtual ~Poller() = default;
+  virtual void poll(EventLoop &loop) = 0;
+};
+} // namespace yawl

--- a/include/Event/Poller.h
+++ b/include/Event/Poller.h
@@ -1,10 +1,15 @@
 #pragma once
 
+#include "Event/Handler.h" // for WindowId
+#include "Windowing/Window.h"
+
 namespace yawl {
 struct EventLoop;
 
 struct Poller {
   virtual ~Poller() = default;
   virtual void poll(EventLoop &loop) = 0;
+  virtual void registerWindow(WindowId id, Window &window) {}
+  virtual void unregisterWindow(WindowId id, Window &window) {}
 };
 } // namespace yawl

--- a/include/Event/XPoller.h
+++ b/include/Event/XPoller.h
@@ -3,12 +3,16 @@
 #ifdef HAVE_X11
 #include "Event/Poller.h"
 #include <External/x11.h>
+#include <unordered_map>
 
 namespace yawl {
 struct XPoller : public Poller {
   explicit XPoller(xcb_connection_t *conn);
 
   void poll(EventLoop &loop) override;
+
+  void registerWindow(WindowId id, Window &window) override;
+  void unregisterWindow(WindowId id, Window &window) override;
 
   xcb_atom_t wm_protocols;
   xcb_atom_t wm_delete_window;
@@ -19,6 +23,7 @@ private:
   void handleDestroyNotify(EventLoop &loop, xcb_destroy_notify_event_t *ev);
 
   xcb_connection_t *connection;
+  std::unordered_map<xcb_window_t, WindowId> windowMap;
 };
 } // namespace yawl
 #endif // HAVE_X11

--- a/include/Event/XPoller.h
+++ b/include/Event/XPoller.h
@@ -1,27 +1,24 @@
 #pragma once
 
 #ifdef HAVE_X11
-#include "Event/Handler.h"
-#include "Windowing/Window.h"
+#include "Event/Poller.h"
 #include <External/x11.h>
 
 namespace yawl {
-struct EventLoop;
+struct XPoller : public Poller {
+  explicit XPoller(xcb_connection_t *conn);
 
-struct XPoller {
-  void poll(EventLoop &loop, WindowId id, Window &window);
+  void poll(EventLoop &loop) override;
+
+  xcb_atom_t wm_protocols;
+  xcb_atom_t wm_delete_window;
 
 private:
-  void handleEvent(EventLoop &loop, WindowId id, xcb_generic_event_t *ev);
-  void handleClientMessage(EventLoop &loop, WindowId id,
-                           xcb_client_message_event_t *ev);
-  void handleDestroyNotify(EventLoop &loop, WindowId id,
-                           xcb_destroy_notify_event_t *ev);
-  
-  // Cache for WM_DELETE_WINDOW atom lookup
-  xcb_atom_t getWmDeleteWindowAtom(xcb_connection_t *conn);
-  
-  static xcb_atom_t cached_wm_delete_window;
+  void handleEvent(EventLoop &loop, xcb_generic_event_t *ev);
+  void handleClientMessage(EventLoop &loop, xcb_client_message_event_t *ev);
+  void handleDestroyNotify(EventLoop &loop, xcb_destroy_notify_event_t *ev);
+
+  xcb_connection_t *connection;
 };
 } // namespace yawl
 #endif // HAVE_X11

--- a/include/Windowing/XClient.h
+++ b/include/Windowing/XClient.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#ifdef HAVE_X11
+#include "Event/Poller.h"
+#include "Utility/Result.h"
+#include <External/x11.h>
+#include <optional>
+#include <memory>
+#include "Event/XPoller.h"
+
+namespace yawl {
+struct EventLoop;
+
+struct XClient {
+  enum class Error {
+    FailedToConnect,
+    FailedToGetScreen,
+    FailedToInitAtoms,
+  };
+
+private:
+  xcb_connection_t *connection;
+  xcb_screen_t *screen;
+  std::unique_ptr<XPoller> poller;
+
+  XClient(xcb_connection_t *conn, xcb_screen_t *scr, std::unique_ptr<XPoller> p);
+
+public:
+  XClient();
+  ~XClient();
+  XClient(XClient &&other) noexcept;
+  XClient &operator=(XClient &&other) noexcept;
+
+  static Result<XClient, Error> connect(std::optional<int> screenIndex = std::nullopt);
+
+  xcb_connection_t *getConnection() const { return connection; }
+  xcb_screen_t *getScreen() const { return screen; }
+  XPoller *getPoller() const { return poller.get(); }
+};
+
+} // namespace yawl
+
+#endif // HAVE_X11

--- a/include/Windowing/XWindow.h
+++ b/include/Windowing/XWindow.h
@@ -6,6 +6,7 @@
 #include "Utility/Result.h"
 #include "Windowing/Descriptor.h"
 #include "Windowing/RawHandle.h"
+#include "Windowing/XClient.h"
 #include <External/x11.h>
 
 namespace yawl {
@@ -32,7 +33,6 @@ private:
   xcb_window_t window;
   bool isOwning;
 
-private:
   XWindow(xcb_connection_t *conn, xcb_screen_t *screen, xcb_window_t win,
           bool owning);
   static Result<xcb_screen_t *, Error> getScreen(xcb_connection_t *conn,
@@ -41,9 +41,6 @@ private:
   static Result<xcb_window_t, Error> createWindow(xcb_connection_t *conn,
                                                   xcb_screen_t *screen,
                                                   const Descriptor &desc);
-
-  static Result<void, Error> setupWmProtocols(xcb_connection_t *conn,
-                                               xcb_window_t window);
 
   Result<void, Error> modifyStringProperty(xcb_atom_t property, xcb_atom_t type,
                                            std::string_view value);
@@ -57,16 +54,15 @@ public:
   XWindow(XWindow &&other) noexcept;
   XWindow &operator=(XWindow &&other) noexcept;
 
-public:
   RawWindowHandle getWindowHandle() const override {
     return RawWindowHandle(connection, window);
-  };
+  }
 
-public:
   xcb_connection_t *getConnection() const { return connection; }
   xcb_window_t getWindow() const { return window; }
   bool isOwningWindow() const { return isOwning; }
 
+  static Result<XWindow, Error> create(XClient &client, const Descriptor &desc);
   static Result<XWindow, Error> create(const Descriptor &desc);
 };
 } // namespace yawl

--- a/include/Yawl.h
+++ b/include/Yawl.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "Utility/Size.h"
 #include "Utility/Result.h"
 #include "Utility/Value.h"
@@ -10,6 +9,7 @@
 #include "Windowing/RawHandle.h"
 #ifdef HAVE_X11
 #include "Windowing/XWindow.h"
+#include "Windowing/XClient.h"
 #endif
 
 #include "Event/Event.h"

--- a/src/Event/Loop.cc
+++ b/src/Event/Loop.cc
@@ -4,24 +4,62 @@
 #endif
 
 namespace yawl {
-EventLoop::EventLoop(Handler &h) : running(true), handler(h) {}
 
-void EventLoop::queueEvent(WindowId id, const Event &event) {
-  eventQueue.push({id, event});
+EventLoop::EventLoop(Handler &h, Poller *p)
+    : running(true), handler(h), poller(p) {}
+
+#ifdef HAVE_X11
+std::optional<WindowId> EventLoop::getWindowId(xcb_window_t win) const {
+  auto it = x11WindowMap.find(win);
+  if (it == x11WindowMap.end())
+    return std::nullopt;
+  return it->second;
 }
+#endif
 
 WindowId EventLoop::mount(std::unique_ptr<Window> window) {
   windows.push_back(std::move(window));
   WindowId id = windows.size() - 1;
+#ifdef HAVE_X11
+  RawWindowHandle handle = windows.back()->getWindowHandle();
+  if (handle.getType() == BackendType::X11) {
+    auto opt = handle.getHandle();
+    if (opt)
+      x11WindowMap[opt->get().x11.window] = id;
+  }
+#endif
   return id;
 }
 
 void EventLoop::unmount(WindowId id) {
   if (id < windows.size()) {
+#ifdef HAVE_X11
+    RawWindowHandle handle = windows[id]->getWindowHandle();
+    if (handle.getType() == BackendType::X11) {
+      auto opt = handle.getHandle();
+      if (opt)
+        x11WindowMap.erase(opt->get().x11.window);
+    }
+#endif
     windows.erase(windows.begin() + id);
+#ifdef HAVE_X11
+    // rebuild mapping to update ids
+    x11WindowMap.clear();
+    for (WindowId i = 0; i < windows.size(); ++i) {
+      RawWindowHandle h = windows[i]->getWindowHandle();
+      if (h.getType() == BackendType::X11) {
+        auto opt = h.getHandle();
+        if (opt)
+          x11WindowMap[opt->get().x11.window] = i;
+      }
+    }
+#endif
   }
 }
 
+void EventLoop::queueEvent(WindowId id, const Event &event) {
+  eventQueue.push({id, event});
+}
 
 void EventLoop::dispatchQueuedEvents() {
   while (!eventQueue.isEmpty()) {
@@ -35,14 +73,10 @@ void EventLoop::dispatchQueuedEvents() {
 
 void EventLoop::run() {
   while (!windows.empty() && running) {
-    for (WindowId i = 0; i < windows.size(); ++i) {
-#ifdef HAVE_X11
-      XPoller poller;
-      poller.poll(*this, i, *windows[i]);
-#endif
-    }
-
+    if (poller)
+      poller->poll(*this);
     dispatchQueuedEvents();
   }
 }
+
 } // namespace yawl

--- a/src/Event/Loop.cc
+++ b/src/Event/Loop.cc
@@ -1,59 +1,25 @@
 #include "Event/Loop.h"
-#ifdef HAVE_X11
-#include "Event/XPoller.h"
-#endif
+
 
 namespace yawl {
 
 EventLoop::EventLoop(Handler &h, Poller *p)
     : running(true), handler(h), poller(p) {}
 
-#ifdef HAVE_X11
-std::optional<WindowId> EventLoop::getWindowId(xcb_window_t win) const {
-  auto it = x11WindowMap.find(win);
-  if (it == x11WindowMap.end())
-    return std::nullopt;
-  return it->second;
-}
-#endif
 
 WindowId EventLoop::mount(std::unique_ptr<Window> window) {
   windows.push_back(std::move(window));
   WindowId id = windows.size() - 1;
-#ifdef HAVE_X11
-  RawWindowHandle handle = windows.back()->getWindowHandle();
-  if (handle.getType() == BackendType::X11) {
-    auto opt = handle.getHandle();
-    if (opt)
-      x11WindowMap[opt->get().x11.window] = id;
-  }
-#endif
+  if (poller)
+    poller->registerWindow(id, *windows.back());
   return id;
 }
 
 void EventLoop::unmount(WindowId id) {
   if (id < windows.size()) {
-#ifdef HAVE_X11
-    RawWindowHandle handle = windows[id]->getWindowHandle();
-    if (handle.getType() == BackendType::X11) {
-      auto opt = handle.getHandle();
-      if (opt)
-        x11WindowMap.erase(opt->get().x11.window);
-    }
-#endif
+    if (poller)
+      poller->unregisterWindow(id, *windows[id]);
     windows.erase(windows.begin() + id);
-#ifdef HAVE_X11
-    // rebuild mapping to update ids
-    x11WindowMap.clear();
-    for (WindowId i = 0; i < windows.size(); ++i) {
-      RawWindowHandle h = windows[i]->getWindowHandle();
-      if (h.getType() == BackendType::X11) {
-        auto opt = h.getHandle();
-        if (opt)
-          x11WindowMap[opt->get().x11.window] = i;
-      }
-    }
-#endif
   }
 }
 

--- a/src/Windowing/RawHandle.cc
+++ b/src/Windowing/RawHandle.cc
@@ -1,13 +1,13 @@
 #include "Windowing/RawHandle.h"
 
 namespace yawl {
-RawWindowHandle::RawWindowHandle() : type(Type::None), handle(std::nullopt) {}
-RawWindowHandle::RawWindowHandle(Type type, Handle handle)
+RawWindowHandle::RawWindowHandle() : type(BackendType::None), handle(std::nullopt) {}
+RawWindowHandle::RawWindowHandle(BackendType type, Handle handle)
     : type(type), handle(handle) {}
 #ifdef HAVE_X11
 RawWindowHandle::RawWindowHandle(xcb_connection_t *connection,
                                  xcb_window_t window)
-    : type(RawWindowHandle::Type::X11) {
+    : type(BackendType::X11) {
   Handle h;
   h.x11.connection = connection;
   h.x11.window = window;

--- a/src/Windowing/XClient.cc
+++ b/src/Windowing/XClient.cc
@@ -1,0 +1,65 @@
+#include "Windowing/XClient.h"
+#ifdef HAVE_X11
+#include "Event/XPoller.h"
+#include <cstdlib>
+#include <memory>
+
+namespace yawl {
+
+XClient::XClient() : connection(nullptr), screen(nullptr), poller(nullptr) {}
+
+XClient::XClient(xcb_connection_t *conn, xcb_screen_t *scr, std::unique_ptr<XPoller> p)
+    : connection(conn), screen(scr), poller(std::move(p)) {}
+
+XClient::~XClient() {
+  if (connection)
+    xcb_disconnect(connection);
+}
+
+XClient::XClient(XClient &&other) noexcept
+    : connection(other.connection), screen(other.screen), poller(std::move(other.poller)) {
+  other.connection = nullptr;
+  other.screen = nullptr;
+}
+
+XClient &XClient::operator=(XClient &&other) noexcept {
+  if (this != &other) {
+    if (connection)
+      xcb_disconnect(connection);
+    connection = other.connection;
+    screen = other.screen;
+    poller = std::move(other.poller);
+    other.connection = nullptr;
+    other.screen = nullptr;
+  }
+  return *this;
+}
+
+Result<XClient, XClient::Error> XClient::connect(std::optional<int> screenIndex) {
+  int default_screen;
+  xcb_connection_t *conn = xcb_connect(nullptr, &default_screen);
+  if (xcb_connection_has_error(conn)) {
+    return Err(Error::FailedToConnect);
+  }
+
+  int target = screenIndex.value_or(default_screen);
+  const xcb_setup_t *setup = xcb_get_setup(conn);
+  xcb_screen_iterator_t iter = xcb_setup_roots_iterator(setup);
+  for (int i = 0; i < target && iter.rem > 1; ++i)
+    xcb_screen_next(&iter);
+
+  if (iter.rem == 0 || iter.data == nullptr) {
+    xcb_disconnect(conn);
+    return Err(Error::FailedToGetScreen);
+  }
+  xcb_screen_t *scr = iter.data;
+
+  auto poller = std::make_unique<XPoller>(conn);
+  if (!poller)
+    return Err(Error::FailedToInitAtoms);
+
+  return Ok(XClient(conn, scr, std::move(poller)));
+}
+
+} // namespace yawl
+#endif // HAVE_X11


### PR DESCRIPTION
## Summary
- create new `Poller` interface and X11-based `XClient`
- move event polling logic into reusable `XPoller`
- update `EventLoop` to accept a `Poller` instance and keep X11 window mapping
- allow creating windows via shared `XClient`
- revise example to use the new API

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/yawl_example` *(fails: Failed to connect to X server)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5c279c08333bad1c6c47b543d32